### PR TITLE
pixelformats: Use pixel groups instead of verticalsubsampling

### DIFF
--- a/tests/print-fmts.py
+++ b/tests/print-fmts.py
@@ -15,7 +15,7 @@ def main():
         else:
             v4l2_fourcc = '    '
 
-        planes = [f'bytespergroup:{p.bytespergroup} vsub:{p.verticalsubsampling}' for p in fmt.planes]
+        planes = [f'bytespergroup:{p.bytespergroup} linespergroup:{p.linespergroup}' for p in fmt.planes]
 
         print(f'{fmt.name:15} {drm_fourcc:4} {v4l2_fourcc:4} pixelspergroup:{fmt.pixelspergroup} {planes}')
 


### PR DESCRIPTION
At some point we have horizontalsubsampling and verticalsubsampling. Then we had bytespergroup and verticalsubsampling, i.e. a mix of the concept of pixel group and subsampling.

Let's just drop the subsampling totally, as we can represent the subsamplings with a rectangular pixel group.

So, now we have 'pixelspergroup' for each PixelFormat, which tells the width and height, in pixels and lines, of a pixel group. And for each plane, we have 'bytespergroup' which tells the number of bytes a pixel group takes horizontally on that plane, and 'linespergroup' which tells the number of lines a pixel group takes on that plane.