### PR TITLE
conv: Use NotImplementedError when no backends are available

### DIFF
--- a/pixutils/conv/conv.py
+++ b/pixutils/conv/conv.py
@@ -100,7 +100,7 @@ def to_bgr888(
     # Get list of backends to try
     backends = get_backends(options.get('backends') if options else None)
     if not backends:
-        raise ValueError('No backends available')
+        raise NotImplementedError('No backends available')
 
     size = 0
 

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -230,10 +230,8 @@ def create_test_function(test_case):
             rgb_buf = buffer_to_bgr888(
                 test_case.pixel_format, WIDTH, HEIGHT, 0, src_buf, test_case.options
             )
-        except ValueError as e:
-            if str(e) == 'No backends available':
-                self.skipTest('No backend available')
-            raise
+        except NotImplementedError as e:
+            raise unittest.SkipTest('No backend available') from e
 
         src_sha = hashlib.sha256(src_buf.tobytes()).hexdigest()
         rgb_sha = hashlib.sha256(rgb_buf.tobytes()).hexdigest()
@@ -283,10 +281,8 @@ def create_stride_test_function(test_case, padded: bool):
 
         try:
             rgb_buf = buffer_to_bgr888(fmt, WIDTH, HEIGHT, bpl, test_buf, test_case.options)
-        except ValueError as e:
-            if str(e) == 'No backends available':
-                self.skipTest('No backend available')
-            raise
+        except NotImplementedError as e:
+            raise unittest.SkipTest('No backend available') from e
 
         rgb_sha = hashlib.sha256(rgb_buf.tobytes()).hexdigest()
         self.assertEqual(
@@ -345,10 +341,8 @@ def create_int_stride_test_function(test_case, padded: bool):
 
         try:
             rgb_buf = buffer_to_bgr888(fmt, WIDTH, HEIGHT, bpl, test_buf, test_case.options)
-        except ValueError as e:
-            if str(e) == 'No backends available':
-                self.skipTest('No backend available')
-            raise
+        except NotImplementedError as e:
+            raise unittest.SkipTest('No backend available') from e
 
         rgb_sha = hashlib.sha256(rgb_buf.tobytes()).hexdigest()
         self.assertEqual(


### PR DESCRIPTION
to_bgr888() raised ValueError when no requested backend was installed and NotImplementedError when an installed backend could not handle the format. Both mean "we can't convert this", so collapse them into one exception type. The tests that probe backends or skip on missing backends can now catch a single exception type instead of matching on the ValueError message string.

Fixes: #11
